### PR TITLE
fix: remove setting log level

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,7 +1,3 @@
-if (process.env.npm_config_loglevel === 'silly') {
-  log.level = 'silly'
-}
-
 const { install } = require('./build/install')
 
 install()


### PR DESCRIPTION
This causes an error when running `npm ci -ddd` as the npmlog require was removed in https://github.com/nut-tree/npm-opencv-build/commit/91d9026490911e7f7bc08d4a65783e941fbc5376#diff-bca55137afc086582855731d4e7750b1c5988a6c5f3917f966e04d8b8c01ec59